### PR TITLE
DAP-42559 - disable S3AFileSystem metrics

### DIFF
--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -23,7 +23,7 @@
     <relativePath>../../hadoop-project</relativePath>
   </parent>
   <artifactId>hadoop-aws</artifactId>
-  <version>3.2.1-datameer-20230712</version>
+  <version>3.2.1-datameer-20231005</version>
   <name>Apache Hadoop Amazon Web Services support</name>
   <description>
     This module contains code to support integration with Amazon Web Services.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -245,7 +245,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities {
     super.initialize(name, conf);
     setConf(conf);
     try {
-      instrumentation = new S3AInstrumentation(name);
+      instrumentation = new S3AInstrumentation(name, false);
 
       // Username is the current user at the time the FS was instantiated.
       username = UserGroupInformation.getCurrentUser().getShortUserName();

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java
@@ -197,7 +197,7 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
       STREAM_WRITE_BLOCK_UPLOADS_DATA_PENDING,
   };
 
-  public S3AInstrumentation(URI name) {
+  public S3AInstrumentation(URI name, boolean metricsEnabled) {
     UUID fileSystemInstanceId = UUID.randomUUID();
     registry.tag(METRIC_TAG_FILESYSTEM_ID,
         "A unique identifier for the instance",
@@ -238,14 +238,20 @@ public class S3AInstrumentation implements Closeable, MetricsSource {
     for (Statistic statistic : GAUGES_TO_CREATE) {
       gauge(statistic.getSymbol(), statistic.getDescription());
     }
-    //todo need a config for the quantiles interval?
-    int interval = 1;
-    putLatencyQuantile = quantiles(S3GUARD_METADATASTORE_PUT_PATH_LATENCY,
-        "ops", "latency", interval);
-    throttleRateQuantile = quantiles(S3GUARD_METADATASTORE_THROTTLE_RATE,
-        "events", "frequency (Hz)", interval);
 
-    registerAsMetricsSource(name);
+    if (metricsEnabled) {
+      //todo need a config for the quantiles interval?
+      int interval = 1;
+      putLatencyQuantile = quantiles(S3GUARD_METADATASTORE_PUT_PATH_LATENCY,
+          "ops", "latency", interval);
+      throttleRateQuantile = quantiles(S3GUARD_METADATASTORE_THROTTLE_RATE,
+          "events", "frequency (Hz)", interval);
+
+      registerAsMetricsSource(name);
+    } else {
+      putLatencyQuantile = null;
+      throttleRateQuantile = null;
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ABlockOutputArray.java
@@ -128,7 +128,7 @@ public class ITestS3ABlockOutputArray extends AbstractS3ATestBase {
   private void markAndResetDatablock(S3ADataBlocks.BlockFactory factory)
       throws Exception {
     S3AInstrumentation instrumentation =
-        new S3AInstrumentation(new URI("s3a://example"));
+        new S3AInstrumentation(new URI("s3a://example"), true);
     S3AInstrumentation.OutputStreamStatistics outstats
         = instrumentation.newOutputStreamStatistics(null);
     S3ADataBlocks.DataBlock block = factory.create(1, BLOCK_SIZE, outstats);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -77,7 +77,7 @@ public class MockS3AFileSystem extends S3AFileSystem {
    */
   private int logEvents = LOG_NAME;
   private final S3AInstrumentation instrumentation =
-      new S3AInstrumentation(FS_URI);
+      new S3AInstrumentation(FS_URI, true);
   private Configuration conf;
   private WriteOperationHelper writeHelper;
 


### PR DESCRIPTION
### Why
`S3AFileSystem` leaks memory when not closed. This happens in `dap` sometimes.

In addition to identifying the leaks in `dap` this disables the metrics completely in `hadoop-aws` code.